### PR TITLE
Fix push stm32f4

### DIFF
--- a/STM32F4/platform.txt
+++ b/STM32F4/platform.txt
@@ -45,11 +45,6 @@ compiler.ar.extra_flags=
 compiler.elf2hex.extra_flags=
 
 
-
-##compiler.libs.c.flags="-I{build.system.path}/libmaple" "-I{build.system.path}/libmaple/include" "-I{build.system.path}/libmaple/stm32f1/include" "-I{build.system.path}/libmaple/stm32f1/include/series" "-I{build.system.path}/libmaple/usb/stm32f1" "-I{build.system.path}/libmaple/usb/usb_lib" 
-#compiler.libs.c.flags="-I{build.system.path}/libmaple" "-I{build.system.path}/libmaple/include" "-I{build.system.path}/libmaple/stm32f1/include"                                                           "-I{build.system.path}/libmaple/usb/stm32f1" "-I{build.system.path}/libmaple/usb/usb_lib" 
-
-
 compiler.libs.c.flags="-I{build.core.path}/libmaple" "-I{build.core.path}/libmaple/usbF4" "-I{build.core.path}/libmaple/usbF4/STM32_USB_Device_Library/Core/inc" "-I{build.core.path}/libmaple/usbF4/STM32_USB_Device_Library/Class/cdc/inc" "-I{build.core.path}/libmaple/usbF4/STM32_USB_OTG_Driver/inc" "-I{build.core.path}/libmaple/usbF4/VCP"
 
 
@@ -80,9 +75,6 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mcpu={b
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-##recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--entry=Reset_Handler -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group "{build.path}/syscalls_sam3.c.o" {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.path}/{archive_file}" -Wl,--end-group
-#-Wl,--entry=__start__ 
-#recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} "{build.variant.path}/{build.variant_system_lib}" "{build.path}/{archive_file}" -Wl,--end-group
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mcpu={build.mcu} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -lm -lgcc -mthumb -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--warn-unresolved-symbols -Wl,--start-group {object_files} -Wl,--whole-archive "{build.path}/{archive_file}" -Wl,--no-whole-archive -Wl,--end-group
 
 ## Create eeprom
@@ -104,9 +96,9 @@ recipe.size.regex.data=^(?:\.data|\.bss|\.noinit)\s+([0-9]+).*
 tools.maple_upload.cmd=maple_upload
 tools.maple_upload.cmd.windows=maple_upload.bat
 #tools.maple_upload.cmd.linux=
-tools.maple_upload.path={runtime.tools.stm32tools.path}/win
-tools.maple_upload.path.macosx={runtime.tools.stm32tools.path}/macosx
-tools.maple_upload.path.linux={runtime.tools.stm32tools.path}/linux
+tools.maple_upload.path={runtime.hardware.path}/tools/{runtime.os}
+#tools.maple_upload.path.macosx={runtime.tools.stm32tools.path}/macosx
+#tools.maple_upload.path.linux={runtime.tools.stm32tools.path}/linux
 
 tools.maple_upload.upload.params.verbose=-d
 tools.maple_upload.upload.params.quiet=
@@ -118,7 +110,7 @@ tools.maple_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altI
 tools.serial_upload.cmd=serial_upload
 tools.serial_upload.cmd.windows=serial_upload.bat
 #tools.serial_upload.cmd.linux=
-tools.serial_upload.path={runtime.tools.stm32tools.path}/win
+tools.serial_upload.path={runtime.hardware.path}/tools/{runtime.os}
 
 tools.serial_upload.upload.params.verbose=-d
 tools.serial_upload.upload.params.quiet=
@@ -128,9 +120,9 @@ tools.serial_upload.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.alt
 
 tools.stlink.cmd=stlink_upload
 tools.stlink.cmd.windows=stlink_upload.bat
-#tools.stlink.cmd.linux=stlink_upload
-tools.stlink.path={runtime.tools.stm32tools.path}/win
-tools.stlink.path.linux={runtime.tools.stm32tools.path}/linux/
+#tools.stlink.cmd.linux=
+tools.stlink.path={runtime.hardware.path}/tools/{runtime.os}
+#tools.stlink.path.linux={runtime.tools.stm32tools.path}/linux/
 tools.stlink.upload.params.verbose=-d
 tools.stlink.upload.params.quiet=
 tools.stlink.upload.pattern="{path}/{cmd}" {serial.port.file} {upload.altID} {upload.usbID} "{build.path}/{build.project_name}.bin"


### PR DESCRIPTION
Hi Dan,

I found the way to fix the issue I was having when pushing to the stm32f4 discovery, I replaced {runtime.tools.stm32tools.path} with {runtime.hardware.path} as recommended on the wiki.

Tested using IDE 1.6.7

let me know if you think there is better way.

Thanks,
