### PR TITLE
Correct CS on SPI1 pin

### DIFF
--- a/STM32F4/variants/discovery_f407/discovery_f4.h
+++ b/STM32F4/variants/discovery_f407/discovery_f4.h
@@ -66,7 +66,7 @@
 #ifdef ARDUINO_STM32F4_NETDUINO2PLUS
 #define BOARD_SPI1_NSS_PIN      Port2Pin('C', 8)
 #else
-#define BOARD_SPI1_NSS_PIN      Port2Pin('A', 4)
+#define BOARD_SPI1_NSS_PIN      Port2Pin('E', 3)
 #endif
 #define BOARD_SPI1_MOSI_PIN     Port2Pin('A', 7)
 #ifdef ARDUINO_STM32F4_NETDUINO2PLUS


### PR DESCRIPTION
Hi Dan,

I changed the pin number for SPI1 CS to the correct one specified in the board specification, figure 14, page 36.

http://www.st.com/st-web-ui/static/active/cn/resource/technical/document/user_manual/DM00039084.pdf

Thanks,
